### PR TITLE
Fcom missing dependencies

### DIFF
--- a/Frends.Community.Azure.QueueStorage.Tests/Frends.Community.Azure.QueueStorage.Tests.csproj
+++ b/Frends.Community.Azure.QueueStorage.Tests/Frends.Community.Azure.QueueStorage.Tests.csproj
@@ -36,14 +36,14 @@
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Edm.5.8.3\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.OData.5.8.3\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.8.3\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAzure.Storage.8.7.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
@@ -57,8 +57,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
+    <Reference Include="System.Spatial, Version=5.8.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Spatial.5.8.3\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -74,6 +74,7 @@
     <Compile Include="QueueTestHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Frends.Community.Azure.QueueStorage.Tests/packages.config
+++ b/Frends.Community.Azure.QueueStorage.Tests/packages.config
@@ -1,16 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
-  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net461" />
-  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net461" />
-  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net461" />
+  <package id="Microsoft.Data.Edm" version="5.8.3" targetFramework="net461" />
+  <package id="Microsoft.Data.OData" version="5.8.3" targetFramework="net461" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
   <package id="NUnit" version="3.9.0" targetFramework="net461" />
   <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net461" />
-  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net461" />
-  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net461" />
-  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net461" />
-  <package id="System.Net.Requests" version="4.0.11" targetFramework="net461" />
-  <package id="System.Spatial" version="5.8.2" targetFramework="net461" />
+  <package id="System.Spatial" version="5.8.3" targetFramework="net461" />
   <package id="WindowsAzure.Storage" version="8.7.0" targetFramework="net461" />
 </packages>

--- a/Frends.Community.Azure.QueueStorage/Frends.Community.Azure.QueueStorage.csproj
+++ b/Frends.Community.Azure.QueueStorage/Frends.Community.Azure.QueueStorage.csproj
@@ -36,14 +36,14 @@
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Edm.5.8.3\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.OData.5.8.3\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.8.3\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAzure.Storage.8.7.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
@@ -54,8 +54,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
+    <Reference Include="System.Spatial, Version=5.8.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Spatial.5.8.3\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -72,6 +72,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Frends.Community.Azure.QueueStorage/packages.config
+++ b/Frends.Community.Azure.QueueStorage/packages.config
@@ -1,14 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
-  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net461" />
-  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net461" />
-  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net461" />
+  <package id="Microsoft.Data.Edm" version="5.8.3" targetFramework="net452" />
+  <package id="Microsoft.Data.OData" version="5.8.3" targetFramework="net452" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
-  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net461" />
-  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net461" />
-  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net461" />
-  <package id="System.Net.Requests" version="4.0.11" targetFramework="net461" />
-  <package id="System.Spatial" version="5.8.2" targetFramework="net461" />
+  <package id="System.Spatial" version="5.8.3" targetFramework="net452" />
   <package id="WindowsAzure.Storage" version="8.7.0" targetFramework="net461" />
 </packages>

--- a/nuspec/Frends.Community.Azure.QueueStorage.nuspec
+++ b/nuspec/Frends.Community.Azure.QueueStorage.nuspec
@@ -2,13 +2,23 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Frends.Community.Azure.QueueStorage</id>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <title>Frends Community Azure Storage Queue</title>
     <authors>HiQ Finland</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Task Azure Storage Queue operations.</description>
     <summary />
     <dependencies>
+      <dependency id="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
+      <dependency id="Microsoft.Data.Edm" version="5.8.2" />
+      <dependency id="Microsoft.Data.OData" version="5.8.2" />
+      <dependency id="Microsoft.Data.Services.Client" version="5.8.2" />
+      <dependency id="Newtonsoft.Json" version="6.0.8" />
+      <dependency id="System.ComponentModel.EventBasedAsync" version="4.0.11" />
+      <dependency id="System.Dynamic.Runtime" version="4.0.0" />
+      <dependency id="System.Linq.Queryable" version="4.0.0" />
+      <dependency id="System.Net.Requests" version="4.0.11" />
+      <dependency id="System.Spatial" version="5.8.2" />
       <dependency id="WindowsAzure.Storage" version="8.7.0" />
     </dependencies>
     <frameworkAssemblies>

--- a/nuspec/Frends.Community.Azure.QueueStorage.nuspec
+++ b/nuspec/Frends.Community.Azure.QueueStorage.nuspec
@@ -11,6 +11,10 @@
     <dependencies>
       <dependency id="Newtonsoft.Json" version="6.0.8" />
       <dependency id="WindowsAzure.Storage" version="8.7.0" />
+      <dependency id="Microsoft.Data.Services.Client" version="5.8.3" />
+      <dependency id="Microsoft.Data.Edm" version="5.8.3" />
+      <dependency id="Microsoft.Data.OData" version="5.8.3" />
+      <dependency id="System.Spatial" version="5.8.3" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />

--- a/nuspec/Frends.Community.Azure.QueueStorage.nuspec
+++ b/nuspec/Frends.Community.Azure.QueueStorage.nuspec
@@ -2,23 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Frends.Community.Azure.QueueStorage</id>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <title>Frends Community Azure Storage Queue</title>
     <authors>HiQ Finland</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Task Azure Storage Queue operations.</description>
     <summary />
     <dependencies>
-      <dependency id="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
-      <dependency id="Microsoft.Data.Edm" version="5.8.2" />
-      <dependency id="Microsoft.Data.OData" version="5.8.2" />
-      <dependency id="Microsoft.Data.Services.Client" version="5.8.2" />
       <dependency id="Newtonsoft.Json" version="6.0.8" />
-      <dependency id="System.ComponentModel.EventBasedAsync" version="4.0.11" />
-      <dependency id="System.Dynamic.Runtime" version="4.0.0" />
-      <dependency id="System.Linq.Queryable" version="4.0.0" />
-      <dependency id="System.Net.Requests" version="4.0.11" />
-      <dependency id="System.Spatial" version="5.8.2" />
       <dependency id="WindowsAzure.Storage" version="8.7.0" />
     </dependencies>
     <frameworkAssemblies>


### PR DESCRIPTION
updated some nuget packages by Microsoft used in Task, as they had invalid dependencies which caused problems when installing.